### PR TITLE
Use ActiveModel::Serializers to serialize snapshots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :production do
   gem 'rails_12factor'
 end
 
+gem 'active_model_serializers'
 gem 'aws-sdk'
 gem 'pg'
 gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.5)
       activesupport (= 4.2.5)
       globalid (>= 0.3.0)
@@ -192,6 +194,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   aws-sdk
   byebug
   coffee-rails (~> 4.1.0)

--- a/app/controllers/snapshots_controller.rb
+++ b/app/controllers/snapshots_controller.rb
@@ -1,14 +1,9 @@
 class SnapshotsController < ApplicationController
-
 	before_filter :make_api_public, only: [:index]
-
 	respond_to :json
 
 	def index
-
 		@snapshots = Snapshot.where(:keyframe => true).order(created_at: :desc)
-		render json: {snapshots: @snapshots}
-
+		render json: @snapshots
 	end
-
 end

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -11,11 +11,4 @@ class Snapshot < ActiveRecord::Base
       ENV['S3_FILE_PREFIX'] + filename.gsub("+", "%2B")
     end
   end
-
-  def as_json(options={})
-      super(:methods => [:file_path],
-            :except => [:filename, :thumbnail]
-      )
-  end
-
 end

--- a/app/serializers/snapshot_serializer.rb
+++ b/app/serializers/snapshot_serializer.rb
@@ -1,0 +1,3 @@
+class SnapshotSerializer < ActiveModel::Serializer
+  attributes :created_at, :file_path, :site
+end


### PR DESCRIPTION
This hasn't been tested yet (since my environment isn't yet set up for it). But it should significantly reduce the size of the /snapshots payload, which currently clocks in at ~200KB. It also introduces serializers, which is a nice pattern to have in Rails :)
